### PR TITLE
Emit blur event when hiding dropdown

### DIFF
--- a/src/vue-timepicker.vue
+++ b/src/vue-timepicker.vue
@@ -198,6 +198,11 @@ export default {
 
     toggleDropdown () {
       this.showDropdown = !this.showDropdown && !this.disabled
+      if (!this.showDropdown) {
+        this.$emit('blur', {
+          ...this.value
+        })
+      }
     },
 
     onHourSelect (value) {


### PR DESCRIPTION
Emit blur event when hiding the dropdown.
"The blur event is fired when an element has lost focus" - https://developer.mozilla.org/en-US/docs/Web/Events/blur